### PR TITLE
Clarify the iOS version where UIKit delegates were `assign`

### DIFF
--- a/_posts/2015-10-14-UIKit-changes-in-iOS-9.md
+++ b/_posts/2015-10-14-UIKit-changes-in-iOS-9.md
@@ -20,7 +20,7 @@ The issue is that a non-zeroing reference ends up pointing to invalid memory (be
 
 ### Playing with fire
 
-Why do these details about weak references matter? Because up until iOS 8, UIKit views that have a `delegate` or `dataSource` property have been declared as the following.
+Why do these details about weak references matter? Because through iOS 8, UIKit views that have a `delegate` or `dataSource` property have been declared as the following.
 
 {% highlight swift %}
 


### PR DESCRIPTION
I wouldn't normally worry about such a small change, except that this post is probably the best resource about this topic on the internet right now and hey, open source